### PR TITLE
[Dialog] Move dialog util to ui_kit.

### DIFF
--- a/lib/src/utils/dialog_utils.dart
+++ b/lib/src/utils/dialog_utils.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class DialogUtils {
+  static Future<void> showAlertDialog({
+    String? title,
+    String? content,
+    String actionText = 'CLOSE',
+    required GlobalKey<NavigatorState> navKey,
+  }) async {
+    await Future.delayed(Duration(milliseconds: 500));
+    await showDialog(
+      useRootNavigator: false,
+      context: navKey.currentState!.overlay!.context,
+      builder: (context) => AlertDialog(
+        title: Text(
+          title ?? '-',
+        ),
+        content: Text(
+          content ?? '-',
+        ),
+        actions: <Widget>[
+          FlatButton(
+            onPressed: () {
+              navKey.currentState!.pop();
+            },
+            child: Text(actionText),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/utils/index.dart
+++ b/lib/src/utils/index.dart
@@ -1,3 +1,4 @@
 export 'after_layout_mixin.dart';
 // export 'log_utils.dart';
 export 'map_keys.dart';
+export 'dialog_utils.dart';


### PR DESCRIPTION
Signed-off-by: Tushar Sharma <tushar@flick2know.com>


## Description
Move DialogUtils to flutter_ui_kit.

Links :

No Link(s) added.

## Commits
 - [Dialog] Move dialog util to ui_kit.


## Tests

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [x] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html