### PR TITLE
feat(color): adding shade for base

### DIFF
--- a/lib/src/config/colors.dart
+++ b/lib/src/config/colors.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'colors_shade.dart';
+
 class AppColors {
   AppColors._();
 
@@ -24,4 +26,12 @@ class AppColors {
   static Color kOutlinedIconButtonBorderColor = Color(0xffDCDCDC);
 
   static Color colorGreenLight = Color(0xFF4BA42A);
+
+  /// Blue Color
+  static const AppMaterialColor kBlueColor = AppMaterialColor(
+    0xFF118AB2,
+    <int, Color>{
+      25:Color(0xFFEFF7FF),
+    },
+  );
 }

--- a/lib/src/config/colors_shade.dart
+++ b/lib/src/config/colors_shade.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/cupertino.dart';
+
+class AppMaterialColor extends ColorSwatch<int> {
+  const AppMaterialColor(super.primary, super.swatch);
+
+  /// The lightest shade.
+  Color get shade25 => _getShade(25);
+
+  /// The  first lightest shade
+  Color get shade50 => _getShade(50);
+
+  /// The  second lightest shade
+  Color get shade75 => _getShade(75);
+
+  /// The third lightest shade.
+  Color get shade100 => _getShade(100);
+
+  /// The fourth lightest shade.
+  Color get shade200 => _getShade(200);
+
+  /// The fifth lightest shade.
+  Color get shade300 => _getShade(300);
+
+  /// The sixth lightest shade.
+  Color get shade400 => _getShade(400);
+
+  /// The default shade.
+  Color get shade500 => _getShade(500);
+
+  /// The fourth darkest shade.
+  Color get shade600 => _getShade(600);
+
+  /// The third darkest shade.
+  Color get shade700 => _getShade(700);
+
+  /// The second darkest shade.
+  Color get shade800 => _getShade(800);
+
+  /// The darkest shade.
+  Color get shade900 => _getShade(900);
+
+  /// if shade not defined default value of shade assigned
+  Color _getShade(int shadeValue) => this[shadeValue] ?? this;
+}

--- a/lib/src/widgets/common/primary_scaffold.dart
+++ b/lib/src/widgets/common/primary_scaffold.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import '../../config/colors.dart';
+
+class BaseScaffold extends Scaffold {
+  BaseScaffold({
+    super.key,
+    super.appBar,
+    super.floatingActionButton,
+    super.floatingActionButtonLocation,
+    super.floatingActionButtonAnimator,
+    super.persistentFooterButtons,
+    super.persistentFooterAlignment = AlignmentDirectional.centerEnd,
+    super.drawer,
+    super.onDrawerChanged,
+    super.endDrawer,
+    super.onEndDrawerChanged,
+    super.bottomNavigationBar,
+    super.bottomSheet,
+    super.backgroundColor,
+    super.resizeToAvoidBottomInset,
+    super.primary = true,
+    super.drawerDragStartBehavior = DragStartBehavior.start,
+    super.extendBody = false,
+    super.extendBodyBehindAppBar = false,
+    super.drawerScrimColor,
+    super.drawerEdgeDragWidth,
+    super.drawerEnableOpenDragGesture = true,
+    super.endDrawerEnableOpenDragGesture = true,
+    super.restorationId,
+    required this.body,
+  }) : super(
+          body: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+                colors: [
+                  Colors.white,
+                  AppColors.kBlueColor.shade25,
+                ],
+              ),
+            ),
+            child: body,
+          ),
+        );
+  final Widget body;
+}


### PR DESCRIPTION
## Problem:
 Flutter's ColorSwatch requires defining all shades (50, 100, 200, ..., 900). This can be cumbersome when you only need a few specific shades and want a default fallback for the rest.

## Solution:
 Create a custom ColorSwatch subclass that allows defining only the required shades and provides a default color for any undefined shades.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html