### PR TITLE
feat(order_amount_summary):Restricting the visibility of stock value  present in van to the user

### DIFF
--- a/lib/src/widgets/order_booking/summary/order_amount_summary.dart
+++ b/lib/src/widgets/order_booking/summary/order_amount_summary.dart
@@ -73,6 +73,7 @@ class OrderAmountSummaryWidget extends StatelessWidget {
     this.compactNumber = false,
     this.payableAmountInSecondCurrency,
     this.showTotalQtyInAllUnits = false,
+    this.isRestrictStockValueVisibility = false,
     super.key,
   });
 
@@ -108,6 +109,7 @@ class OrderAmountSummaryWidget extends StatelessWidget {
   final String? payableAmountInSecondCurrency;
   final bool showTotalQtyInAllUnits;
 
+  final bool isRestrictStockValueVisibility;
   final titleTextStyle = TextStyle(
     fontWeight: FontWeight.w500,
     color: Colors.black87,
@@ -232,94 +234,95 @@ class OrderAmountSummaryWidget extends StatelessWidget {
               discountWidget!,
               DottedDivider(),
             ],
-            ExpansionTile(
-              shape: RoundedRectangleBorder(side: BorderSide.none),
-              visualDensity: VisualDensity(
-                  horizontal: VisualDensity.minimumDensity,
-                  vertical: VisualDensity.minimumDensity),
-              childrenPadding:
-                  EdgeInsets.only(left: 16 + 45, right: 16, top: 8, bottom: 8),
-              leading: SvgPicture.asset(
-                SvgIcons.cashIcon,
-                height: 25,
-                width: 25,
-              ),
-              title: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    payableAmtTitleText ?? "Payable Amount",
-                    style: titleTextStyle,
-                  ),
-                  Spacer(),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Text(
-                        "$currency $payableAmount",
-                        style: titleTextStyle,
-                      ),
-                      if (payableAmountInSecondCurrency != null)
-                        Text(
-                          "(\u0024 $payableAmountInSecondCurrency)",
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w400,
-                          ),
-                        )
-                    ],
-                  )
-                ],
-              ),
-              initiallyExpanded: true,
-              trailing: (showMargin || amountBreakdownList.isNotEmpty)
-                  ? null
-                  : SizedBox.shrink(),
-              children: [
-                if (showMargin)
-                  Padding(
-                    padding: breakDownListPadding,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            if (!isRestrictStockValueVisibility)
+              ExpansionTile(
+                shape: RoundedRectangleBorder(side: BorderSide.none),
+                visualDensity: VisualDensity(
+                    horizontal: VisualDensity.minimumDensity,
+                    vertical: VisualDensity.minimumDensity),
+                childrenPadding: EdgeInsets.only(
+                    left: 16 + 45, right: 16, top: 8, bottom: 8),
+                leading: SvgPicture.asset(
+                  SvgIcons.cashIcon,
+                  height: 25,
+                  width: 25,
+                ),
+                title: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      payableAmtTitleText ?? "Payable Amount",
+                      style: titleTextStyle,
+                    ),
+                    Spacer(),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
                         Text(
-                          "Margin (%)",
-                          style: subTitleTextStyle.copyWith(
-                              color: AppColors.colorGreenLight),
+                          "$currency $payableAmount",
+                          style: titleTextStyle,
                         ),
-                        Text(
-                          "$currency $marginAmount ($marginPercentage%)",
-                          style: subTitleTextStyle.copyWith(
-                              color: AppColors.colorGreenLight),
-                        ),
+                        if (payableAmountInSecondCurrency != null)
+                          Text(
+                            "(\u0024 $payableAmountInSecondCurrency)",
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w400,
+                            ),
+                          )
                       ],
-                    ),
-                  ),
-                ...List.generate(
-                  amountBreakdownList.length,
-                  (index) {
-                    final amtBreakdownItem = amountBreakdownList[index];
-                    return Padding(
+                    )
+                  ],
+                ),
+                initiallyExpanded: true,
+                trailing: (showMargin || amountBreakdownList.isNotEmpty)
+                    ? null
+                    : SizedBox.shrink(),
+                children: [
+                  if (showMargin)
+                    Padding(
                       padding: breakDownListPadding,
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text(amtBreakdownItem.type,
-                              style: amtBreakdownItem.typeStyle ??
-                                  subTitleTextStyle),
                           Text(
-                            "${amtBreakdownItem.amtPrefix}$currency ${currencyUtil.formatNumber(amtBreakdownItem.amount, compact: compactNumber)}",
+                            "Margin (%)",
                             style: subTitleTextStyle.copyWith(
-                              color: amtBreakdownItem.color ?? Colors.black,
-                            ),
+                                color: AppColors.colorGreenLight),
+                          ),
+                          Text(
+                            "$currency $marginAmount ($marginPercentage%)",
+                            style: subTitleTextStyle.copyWith(
+                                color: AppColors.colorGreenLight),
                           ),
                         ],
                       ),
-                    );
-                  },
-                ),
-              ],
-            ),
+                    ),
+                  ...List.generate(
+                    amountBreakdownList.length,
+                    (index) {
+                      final amtBreakdownItem = amountBreakdownList[index];
+                      return Padding(
+                        padding: breakDownListPadding,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(amtBreakdownItem.type,
+                                style: amtBreakdownItem.typeStyle ??
+                                    subTitleTextStyle),
+                            Text(
+                              "${amtBreakdownItem.amtPrefix}$currency ${currencyUtil.formatNumber(amtBreakdownItem.amount, compact: compactNumber)}",
+                              style: subTitleTextStyle.copyWith(
+                                color: amtBreakdownItem.color ?? Colors.black,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
             if (decimalInfoString != null)
               Padding(
                 padding: EdgeInsets.fromLTRB(16, 16, 16, 2),


### PR DESCRIPTION
## Description

Hide   sub-wideget that  show the amount based on company setting.

Links :
https://dev.azure.com/flick2know/Field_Assist/_sprints/taskboard/pod-mt-international-cst-maintenance/Field_Assist/MT%20International%20CST%20maintenance%20Pod/pot-mt-international-cst-maintenance-sprint4?workitem=137180

No Link(s) added.


## Commits

<!--
- Commit 1
- Commit 2
-->

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html