### PR TITLE
fix(theme): color and background should not used in same widget as per flutter

### DIFF
--- a/lib/src/config/theme/theme_light.dart
+++ b/lib/src/config/theme/theme_light.dart
@@ -27,7 +27,6 @@ class MyTheme {
           elevation: 0,
           titleSpacing: 8,
           toolbarHeight: 60,
-          color: Colors.white,
           backgroundColor: AppColors.kBlueColor.shade25,
           systemOverlayStyle: SystemUiOverlayStyle.light.copyWith(
             statusBarColor: AppColors.kBlueColor.shade25,
@@ -55,7 +54,6 @@ class MyTheme {
           elevation: 0,
           titleSpacing: 8,
           toolbarHeight: 60,
-          color: Colors.white,
           backgroundColor: AppColors.kBlueColor.shade25,
           systemOverlayStyle: SystemUiOverlayStyle.light.copyWith(
             statusBarColor: AppColors.kBlueColor.shade25,


### PR DESCRIPTION
## Description

color and background should not used in same widget as per flutter
<img width="413" height="480" alt="image" src="https://github.com/user-attachments/assets/6af4a472-1d81-4485-a1b4-5bdf531dc3cd" />


Links :

No Link(s) added.


## Commits

<!--
- Commit 1
- Commit 2
-->

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html