### PR TITLE
fix(currencyUtil): minor fix in decimal digits

### DIFF
--- a/lib/src/core/location_info/location_info.dart
+++ b/lib/src/core/location_info/location_info.dart
@@ -73,7 +73,7 @@ class LocationInfoImpl implements LocationInfo {
       /// This is done because iOS app gets rejected if we ask for location
       /// on splash and if it is disabled, user is asked to turn on the location
       /// to use the app
-      if(!Platform.isIOS){
+      if (!Platform.isIOS) {
         final permissionStatus = await isLocationPermissionGranted();
 
         if (!permissionStatus) {

--- a/lib/src/utils/currency/helper.dart
+++ b/lib/src/utils/currency/helper.dart
@@ -109,6 +109,7 @@ class CurrencyUtil {
       getDecimalVal(value);
 
   double getDecimalVal(num value) {
+    if (value.abs() < 1e-12) return 0.0;
     final _amt = Decimal.parse(value.toString());
 
     final epsilon = Decimal.parse("0.00000000000001");

--- a/lib/src/utils/currency/helper.dart
+++ b/lib/src/utils/currency/helper.dart
@@ -43,7 +43,7 @@ class CurrencyUtil {
     final compactResult = _getCompactFormatResult(normalizedValue);
     final compactValue = compactResult.value;
     final usedDecimalDigits = passedDecimalDigits ??
-        ((compactValue % 1 != 0 || inputValue % 1 != 0) ? decimalDigits : 0);
+        (( (useCompact && compactValue % 1 != 0) || inputValue % 1 != 0) ? decimalDigits : 0);
     final localFormatter = locale.getCurrencyFormatNoSymbol(usedDecimalDigits);
 
     try {

--- a/lib/src/utils/currency/helper.dart
+++ b/lib/src/utils/currency/helper.dart
@@ -5,14 +5,14 @@ import 'package:fa_flutter_ui_kit/src/utils/currency/models.dart';
 class CurrencyUtil {
   bool isInternationalCompany;
   bool companyUsesFrenchForCurrencyConversion;
-  int decimalDigits;
+  int? decimalDigits;
   final CurrencyLocale locale;
   final bool useCompactFormat;
 
   CurrencyUtil({
     this.isInternationalCompany = false,
     this.companyUsesFrenchForCurrencyConversion = false,
-    this.decimalDigits = 2,
+    this.decimalDigits,
     this.locale = CurrencyLocale.indian,
     this.useCompactFormat = false,
   });
@@ -42,8 +42,11 @@ class CurrencyUtil {
     final normalizedValue = roundNumber(inputValue);
     final compactResult = _getCompactFormatResult(normalizedValue);
     final compactValue = compactResult.value;
-    final usedDecimalDigits = passedDecimalDigits ??
-        (( (useCompact && compactValue % 1 != 0) || inputValue % 1 != 0) ? decimalDigits : 0);
+    final int usedDecimalDigits = (passedDecimalDigits ??
+        decimalDigits ??
+        (((useCompact && compactValue % 1 != 0) || inputValue % 1 != 0)
+            ? 2
+            : 0));
     final localFormatter = locale.getCurrencyFormatNoSymbol(usedDecimalDigits);
 
     try {
@@ -69,8 +72,8 @@ class CurrencyUtil {
     num value, {
     int? passedDecimalDigits,
   }) {
-    final usedDecimalDigits =
-        passedDecimalDigits ?? (value % 1 == 0 ? 0 : decimalDigits);
+    final int usedDecimalDigits =
+        (passedDecimalDigits ?? decimalDigits ?? (value % 1 == 0 ? 0 : 2));
     final normalizedValue = roundNumber(value);
 
     final localFormatter = locale.getCurrencyFormat(usedDecimalDigits);


### PR DESCRIPTION
## Description

The decimal digits will be shown only when:

passedDecimalDigits is provided — it will be used directly.
if decimalDigits is set in the class, it will be used.

Otherwise, decimalDigits = 2 will be used if:
    - useCompact = false and the original input has a fractional part, or
    - useCompact = true and the compacted value has a fractional part.
If none of the above conditions are met, then 0 decimal digits will be used.
  

Links :

No Link(s) added.


## Commits

<!--
- Commit 1
- Commit 2
-->

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [x] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html