### PR TITLE
fix(qty-input): initialize text controller with empty string if prefill value is null

### DIFF
--- a/lib/src/modules/order/widgets/qty_input_text_box.dart
+++ b/lib/src/modules/order/widgets/qty_input_text_box.dart
@@ -93,9 +93,7 @@ class _QtyInputTextBoxState extends State<QtyInputTextBox> {
 
   void init() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (widget.prefillValue != null) {
-        textController.text = widget.prefillValue.toString();
-      }
+      textController.text = widget.prefillValue?.toString() ?? '';
     });
   }
 


### PR DESCRIPTION
## Description

initialize text controller with empty string if prefill value is null
https://dev.azure.com/flick2know/Field_Assist/_workitems/edit/154668/


## Commits

<!--
- Commit 1
- Commit 2
-->

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html