### PR TITLE
refactor(currency-utils): formatting to drop unnecessary trailing zeros

### DIFF
--- a/lib/src/utils/currency/helper.dart
+++ b/lib/src/utils/currency/helper.dart
@@ -42,11 +42,10 @@ class CurrencyUtil {
     final normalizedValue = roundNumber(inputValue);
     final compactResult = _getCompactFormatResult(normalizedValue);
     final compactValue = compactResult.value;
-    final int usedDecimalDigits = (passedDecimalDigits ??
-        decimalDigits ??
-        (((useCompact && compactValue % 1 != 0) || inputValue % 1 != 0)
-            ? 2
-            : 0));
+    final int usedDecimalDigits =
+        ((useCompact && compactValue % 1 != 0) || inputValue % 1 != 0)
+            ? (passedDecimalDigits ?? decimalDigits ?? 2)
+            : 0;
     final localFormatter = locale.getCurrencyFormatNoSymbol(usedDecimalDigits);
 
     try {
@@ -88,7 +87,9 @@ class CurrencyUtil {
 
   String getFormattedInrDouble(num amount, {bool? compact}) =>
       formatNumber(amount, compact: compact);
+
   String getFormattedInrInt(num amount) => formatCurrency(amount);
+
   String getFormattedIntDouble2Places(num amount, {bool? compact}) =>
       formatNumber(amount, compact: compact, passedDecimalDigits: 2);
 


### PR DESCRIPTION
## Description
Updated number formatting logic so that values like 2.00 are now displayed as 2

Links :
https://app.asana.com/1/34125054317482/project/1201093094056877/task/1211435566653410?focus=true


## Commits

<!--
- Commit 1
- Commit 2
-->

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html