### PR TITLE
fix(gulf-one): add package name to loading indicators

### DIFF
--- a/lib/src/widgets/common/common_progress_dialog.dart
+++ b/lib/src/widgets/common/common_progress_dialog.dart
@@ -1,10 +1,10 @@
 import 'package:cool_flare/flare_actor.dart';
-import 'package:fa_flutter_core/fa_flutter_core.dart';
 import 'package:fa_flutter_ui_kit/fa_flutter_ui_kit.dart';
 import 'package:fa_flutter_ui_kit/src/widgets/common/progress_dialog/progress_dialog.dart';
 import 'package:flutter/material.dart';
 
-Widget _defaultProgressWidget = Image.asset(Images.doubleRingLoader);
+Widget _defaultProgressWidget =
+    Image.asset(Images.doubleRingLoader, package: 'fa_flutter_ui_kit');
 
 class CommonProgressDialog {
   static ProgressDialog? _dialog;

--- a/lib/src/widgets/common/progress_dialog/fa_progress_dialog.dart
+++ b/lib/src/widgets/common/progress_dialog/fa_progress_dialog.dart
@@ -5,7 +5,8 @@ import 'package:flutter/material.dart';
 
 import 'progress_dialog.dart';
 
-Widget _defaultProgressWidget = Image.asset(Images.doubleRingLoader);
+Widget _defaultProgressWidget =
+    Image.asset(Images.doubleRingLoader, package: 'fa_flutter_ui_kit');
 
 class FAProgressDialog {
   static ProgressDialog? _dialog;


### PR DESCRIPTION
## Description
Add package name to svg icons to load these assets from parent app.

## Commits

<!--
- Commit 1
- Commit 2
-->

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html