### PR TITLE
fix(app-assets): add package name to assets loading components

### DIFF
--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -1,6 +1,8 @@
 class Constants {
   Constants._();
 
+  static const String appName = "fa_flutter_ui_kit";
+
   static const String errorSomethingWentWrong = "Oops! Something went wrong.";
 
   static const String locationNotAvailable = "Location not available!";

--- a/lib/src/widgets/common/app_logo.dart
+++ b/lib/src/widgets/common/app_logo.dart
@@ -1,3 +1,4 @@
+import 'package:fa_flutter_ui_kit/src/constants/constants.dart';
 import 'package:fa_flutter_ui_kit/src/constants/images.dart';
 import 'package:flutter/material.dart';
 
@@ -17,6 +18,7 @@ class FieldAssistLogo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Image.asset(
       Images.fieldAssistFullLogo,
+      package: Constants.appName,
       color: foregroundColor,
       width: width,
       height: height,

--- a/lib/src/widgets/common/common_progress_dialog.dart
+++ b/lib/src/widgets/common/common_progress_dialog.dart
@@ -4,7 +4,7 @@ import 'package:fa_flutter_ui_kit/src/widgets/common/progress_dialog/progress_di
 import 'package:flutter/material.dart';
 
 Widget _defaultProgressWidget =
-    Image.asset(Images.doubleRingLoader, package: 'fa_flutter_ui_kit');
+    Image.asset(Images.doubleRingLoader, package: Constants.appName);
 
 class CommonProgressDialog {
   static ProgressDialog? _dialog;

--- a/lib/src/widgets/common/data_loading_progress/data_loading_progress_widget.dart
+++ b/lib/src/widgets/common/data_loading_progress/data_loading_progress_widget.dart
@@ -124,7 +124,7 @@ class DataLoadingProgressWidget extends StatelessWidget {
                                       : Svgs.checkMarkRounded,
                                   height: 20,
                                   width: 20,
-                                  package: 'fa_flutter_ui_kit',
+                                  package: Constants.appName,
                                 )
                               // status == apiStatus.error
                               else

--- a/lib/src/widgets/common/empty_data_widget.dart
+++ b/lib/src/widgets/common/empty_data_widget.dart
@@ -1,3 +1,4 @@
+import 'package:fa_flutter_ui_kit/src/constants/constants.dart';
 import 'package:fa_flutter_ui_kit/src/constants/images.dart';
 import 'package:flutter/material.dart';
 
@@ -23,6 +24,7 @@ class EmptyDataWidget extends StatelessWidget {
           messageLogo ??
               Image.asset(
                 Images.binoculars,
+                package: Constants.appName,
                 width: MediaQuery.of(context).size.width * 0.5,
               ),
           Text(

--- a/lib/src/widgets/common/error/location_error.dart
+++ b/lib/src/widgets/common/error/location_error.dart
@@ -29,6 +29,7 @@ class LocationErrorWidget extends StatelessWidget {
           children: [
             Image.asset(
               Images.superCommander,
+              package: Constants.appName,
               width: MediaQuery.of(context).size.shortestSide / 2,
             ),
             SizedBox(

--- a/lib/src/widgets/common/error/server_error.dart
+++ b/lib/src/widgets/common/error/server_error.dart
@@ -21,6 +21,7 @@ class ServerErrorWidget extends StatelessWidget {
         children: [
           Image.asset(
             Images.superCommander,
+            package: Constants.appName,
             width: MediaQuery.of(context).size.shortestSide / 2,
           ),
           SizedBox(

--- a/lib/src/widgets/common/error/unknown_error.dart
+++ b/lib/src/widgets/common/error/unknown_error.dart
@@ -41,6 +41,7 @@ class UnknownErrorWidget extends StatelessWidget {
           if (showErrorImage) ...[
             Image.asset(
               errorImage,
+              package: Constants.appName,
               width: MediaQuery.of(context).size.width * 0.5,
             ),
             SizedBox(

--- a/lib/src/widgets/common/internet_not_available.dart
+++ b/lib/src/widgets/common/internet_not_available.dart
@@ -24,6 +24,7 @@ class InternetNotAvailable extends StatelessWidget {
             ),*/
             Image.asset(
               Images.noInternet,
+              package: Constants.appName,
               width: MediaQuery.of(context).size.width * 0.5,
             ),
             SizedBox(

--- a/lib/src/widgets/common/launching_growth.dart
+++ b/lib/src/widgets/common/launching_growth.dart
@@ -1,3 +1,4 @@
+import 'package:fa_flutter_ui_kit/src/constants/constants.dart';
 import 'package:fa_flutter_ui_kit/src/constants/images.dart';
 import 'package:flutter/material.dart';
 
@@ -14,6 +15,7 @@ class LaunchingGrowthImage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Image.asset(
       Images.launchingGrowth,
+      package: Constants.appName,
       color: foregroundColor,
       width: width,
       height: height,

--- a/lib/src/widgets/common/no_items_found.dart
+++ b/lib/src/widgets/common/no_items_found.dart
@@ -1,4 +1,5 @@
 import 'package:fa_flutter_core/fa_flutter_core.dart';
+import 'package:fa_flutter_ui_kit/src/constants/constants.dart';
 import 'package:flutter/material.dart';
 
 class NoItemsFound extends StatelessWidget {
@@ -27,7 +28,7 @@ class NoItemsFound extends StatelessWidget {
           children: <Widget>[
             Image.asset(
               "assets/images/empty_carton.png",
-              package: 'fa_flutter_ui_kit',
+              package: Constants.appName,
             ),
             SizedBox(
               height: 10,

--- a/lib/src/widgets/common/progress_dialog/fa_progress_dialog.dart
+++ b/lib/src/widgets/common/progress_dialog/fa_progress_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:cool_flare/flare_actor.dart';
+import 'package:fa_flutter_ui_kit/src/constants/constants.dart';
 import 'package:fa_flutter_ui_kit/src/constants/flares.dart';
 import 'package:fa_flutter_ui_kit/src/constants/images.dart';
 import 'package:flutter/material.dart';
@@ -6,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'progress_dialog.dart';
 
 Widget _defaultProgressWidget =
-    Image.asset(Images.doubleRingLoader, package: 'fa_flutter_ui_kit');
+    Image.asset(Images.doubleRingLoader, package: Constants.appName);
 
 class FAProgressDialog {
   static ProgressDialog? _dialog;

--- a/lib/src/widgets/common/svg_asset_icon.dart
+++ b/lib/src/widgets/common/svg_asset_icon.dart
@@ -1,4 +1,5 @@
 import 'package:fa_flutter_core/fa_flutter_core.dart';
+import 'package:fa_flutter_ui_kit/src/constants/constants.dart';
 import 'package:flutter/material.dart';
 
 class SvgAssetIcon extends StatelessWidget {
@@ -9,7 +10,7 @@ class SvgAssetIcon extends StatelessWidget {
     this.color,
     this.labelText = "",
     this.padding,
-    this.package,
+    this.package = Constants.appName,
   });
 
   final String path;
@@ -18,7 +19,7 @@ class SvgAssetIcon extends StatelessWidget {
   final Color? color;
   final String labelText;
   final double? padding;
-  final String? package;
+  final String package;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/common/svg_asset_img.dart
+++ b/lib/src/widgets/common/svg_asset_img.dart
@@ -1,4 +1,5 @@
 import 'package:fa_flutter_core/fa_flutter_core.dart';
+import 'package:fa_flutter_ui_kit/src/constants/constants.dart';
 import 'package:flutter/material.dart';
 
 class SvgAssetImage extends StatelessWidget {
@@ -8,7 +9,7 @@ class SvgAssetImage extends StatelessWidget {
     this.width = 200,
     this.labelText = "",
     this.iconColor,
-    this.package,
+    this.package = Constants.appName,
   });
 
   final String path;
@@ -16,7 +17,7 @@ class SvgAssetImage extends StatelessWidget {
   final double width;
   final String labelText;
   final Color? iconColor;
-  final String? package;
+  final String package;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/order_booking/summary/order_amount_summary.dart
+++ b/lib/src/widgets/order_booking/summary/order_amount_summary.dart
@@ -101,6 +101,7 @@ class OrderAmountSummaryWidget extends StatelessWidget {
   final titleTextStyle = TextStyle(
     fontWeight: FontWeight.w500,
     color: Colors.black87,
+    fontSize: 15,
   );
   final subTitleTextStyle = TextStyle(
     fontWeight: FontWeight.w500,
@@ -128,6 +129,7 @@ class OrderAmountSummaryWidget extends StatelessWidget {
                     VisualDensity(horizontal: VisualDensity.minimumDensity),
                 leading: SvgPicture.asset(
                   SvgIcons.distributorIcon,
+                  package: Constants.appName,
                   height: 25,
                   width: 25,
                 ),
@@ -184,6 +186,7 @@ class OrderAmountSummaryWidget extends StatelessWidget {
               ),
               leading: SvgPicture.asset(
                 SvgIcons.boxIcon,
+                package: Constants.appName,
                 height: 25,
                 width: 25,
               ),
@@ -236,6 +239,7 @@ class OrderAmountSummaryWidget extends StatelessWidget {
                     left: 16 + 45, right: 16, top: 8, bottom: 8),
                 leading: SvgPicture.asset(
                   SvgIcons.cashIcon,
+                  package: Constants.appName,
                   height: 25,
                   width: 25,
                 ),


### PR DESCRIPTION
## Description
Add package name to all the icons and images loading in the application. This will help  parents app to load this projects assets as a package/module.


## Commits

<!--
- Commit 1
- Commit 2
-->

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html