### PR TITLE
hot-fix(currency): adjust small decimal formatting logic

### DIFF
--- a/lib/src/utils/currency/helper.dart
+++ b/lib/src/utils/currency/helper.dart
@@ -47,11 +47,14 @@ class CurrencyUtil {
         roundNumber(inputValue, fractionDigits: requiredDecimalDigits);
     final compactResult = _getCompactFormatResult(normalizedValue);
     final compactValue = compactResult.value;
-    final int usedDecimalDigits = (showExplicitDecimals ||
-            (useCompact && compactValue % 1 != 0) ||
-            inputValue % 1 != 0)
+    final int usedDecimalDigits = showExplicitDecimals
         ? requiredDecimalDigits
-        : 0;
+        : roundNumber(normalizedValue) == roundNumber(normalizedValue).toInt()
+            ? 0
+            : roundNumber(normalizedValue * 10) ==
+                    roundNumber(normalizedValue * 10).toInt()
+                ? 1
+                : requiredDecimalDigits;
     final localFormatter = locale.getCurrencyFormatNoSymbol(usedDecimalDigits);
 
     try {


### PR DESCRIPTION
## Description

Moved dynamic decimal precision handling into `CurrencyUtil.formatNumber()` to centralize formatting behavior and remove duplicate UI-level logic.

Examples:
- `6` -> `6`
- `6.2` -> `6.2`
- `6.26` -> `6.26`
- `0.3` -> `0.3`
- `1250` -> `1.2K`

Links :

Asana: https://app.asana.com/1/34125054317482/project/1200301693863971/task/1214652452633418?focus=true

## Commits

- Commit 1: hot-fix(currency): adjust small decimal formatting logic

## Tests

I added the following tests:

No Test(s) added.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Best Practices Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] Added relevant reviewers.

## Breaking Change

- [x] No, no existing tests failed.
- [ ] Yes, this is a breaking change.

## Should be merge type:

- [ ] Squash and merge
- [ ] Rebase and merge


<!-- Links -->
[Best Practices Guide]: https://techdocs.fieldassist.io/guide/flutter-docs/best-practices.html